### PR TITLE
Add override hooks for generated controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,32 @@ This is enabled by default when you include the sprout-runtime dependency. It'll
 
 ### Method-Level Security
 In addition to the `@SproutPolicy` annotation, you can use the `sprout.security.enabled` property to enable method-level security for your endpoints. This will use Spring Security to enforce access control based on the policies defined in your entities.
+
+## Customizing Generated Endpoints
+
+Sprout generates controllers in the `...generated.controllers` package. For every controller there is now a matching `Sprout<Entity>ControllerOverride` interface. You can implement this interface in your application and register it as a Spring bean (e.g. using `@Component`) to override individual endpoints or inject additional business logic without touching the generated sources.
+
+Every override method returns an `Optional<ResponseEntity<...>>`. If the optional contains a value, the controller will use your response. If it is empty, Sprout falls back to the default implementation. You can use the provided static helper methods such as `SproutBookControllerOverride.defaultGetById(id, service)` when you only need to extend the standard behaviour.
+
+```java
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class CustomBookOverride implements SproutBookControllerOverride {
+
+    @Override
+    public Optional<ResponseEntity<Book>> getById(Long id, SproutBookService service) {
+        return service.findById(id)
+                .filter(Book::isPublished)
+                .map(ResponseEntity::ok);
+    }
+
+    @Override
+    public Optional<ResponseEntity<Book>> create(Book entity, SproutBookService service) {
+        // Do some custom validation and delegate to the default behaviour afterwards
+        validate(entity);
+        return Optional.of(SproutBookControllerOverride.defaultCreate(entity, service));
+    }
+}
+```
+
+Multiple overrides can be registered for the same entity. Sprout injects them in the order defined by Spring (using `@Order`/`Ordered` or `@Priority`), so you can build pipelines of custom logic when needed.

--- a/sprout-processor/src/main/java/de/flix29/sprout/processor/SproutControllerOverrideGenerator.java
+++ b/sprout-processor/src/main/java/de/flix29/sprout/processor/SproutControllerOverrideGenerator.java
@@ -1,0 +1,177 @@
+package de.flix29.sprout.processor;
+
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+
+public class SproutControllerOverrideGenerator {
+
+    private static final ClassName OPTIONAL_CLASS = ClassName.get("java.util", "Optional");
+    private static final ClassName RESPONSE_ENTITY_CLASS = ClassName.get("org.springframework.http", "ResponseEntity");
+    private static final ClassName LIST_CLASS = ClassName.get("java.util", "List");
+    private static final ClassName HTTP_STATUS_CLASS = ClassName.get("org.springframework.http", "HttpStatus");
+
+    private SproutControllerOverrideGenerator() {
+        // Utility class
+    }
+
+    protected static TypeSpec.Builder generateControllerOverride(
+            TypeElement type,
+            String simpleName,
+            String basePackage,
+            boolean readOnly,
+            TypeMirror idType
+    ) {
+        ClassName entityType = ClassName.get(type);
+        ClassName serviceType = ClassName.get(basePackage + ".services", "Sprout" + simpleName + "Service");
+        TypeName idClassName = TypeName.get(idType);
+
+        TypeSpec.Builder builder = TypeSpec.interfaceBuilder("Sprout" + simpleName + "ControllerOverride")
+                .addModifiers(Modifier.PUBLIC);
+
+        addGetAllOverride(builder, entityType, serviceType);
+        addGetByIdOverride(builder, entityType, serviceType, idClassName);
+
+        if (!readOnly) {
+            addCreateOverride(builder, entityType, serviceType);
+            addUpdateOverride(builder, entityType, serviceType, idClassName);
+            addDeleteOverride(builder, serviceType, idClassName);
+        }
+
+        return builder;
+    }
+
+    private static void addGetAllOverride(TypeSpec.Builder builder, ClassName entityType, ClassName serviceType) {
+        TypeName listType = ParameterizedTypeName.get(LIST_CLASS, entityType);
+        TypeName responseType = ParameterizedTypeName.get(RESPONSE_ENTITY_CLASS, listType);
+        TypeName optionalResponse = ParameterizedTypeName.get(OPTIONAL_CLASS, responseType);
+
+        builder.addMethod(MethodSpec.methodBuilder("getAll")
+                .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
+                .addParameter(serviceType, "service")
+                .returns(optionalResponse)
+                .addStatement("return $T.empty()", OPTIONAL_CLASS)
+                .build());
+
+        builder.addMethod(MethodSpec.methodBuilder("defaultGetAll")
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .addParameter(serviceType, "service")
+                .returns(responseType)
+                .addStatement("return $T.ok(service.findAll())", RESPONSE_ENTITY_CLASS)
+                .build());
+    }
+
+    private static void addGetByIdOverride(
+            TypeSpec.Builder builder,
+            ClassName entityType,
+            ClassName serviceType,
+            TypeName idType
+    ) {
+        TypeName responseType = ParameterizedTypeName.get(RESPONSE_ENTITY_CLASS, entityType);
+        TypeName optionalResponse = ParameterizedTypeName.get(OPTIONAL_CLASS, responseType);
+
+        builder.addMethod(MethodSpec.methodBuilder("getById")
+                .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
+                .addParameter(idType, "id")
+                .addParameter(serviceType, "service")
+                .returns(optionalResponse)
+                .addStatement("return $T.empty()", OPTIONAL_CLASS)
+                .build());
+
+        builder.addMethod(MethodSpec.methodBuilder("defaultGetById")
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .addParameter(idType, "id")
+                .addParameter(serviceType, "service")
+                .returns(responseType)
+                .addStatement("return service.findById(id)"
+                        + "\n        .map($T::ok)"
+                        + "\n        .orElse($T.notFound().build())",
+                        RESPONSE_ENTITY_CLASS, RESPONSE_ENTITY_CLASS)
+                .build());
+    }
+
+    private static void addCreateOverride(TypeSpec.Builder builder, ClassName entityType, ClassName serviceType) {
+        TypeName responseType = ParameterizedTypeName.get(RESPONSE_ENTITY_CLASS, entityType);
+        TypeName optionalResponse = ParameterizedTypeName.get(OPTIONAL_CLASS, responseType);
+
+        builder.addMethod(MethodSpec.methodBuilder("create")
+                .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
+                .addParameter(entityType, "entity")
+                .addParameter(serviceType, "service")
+                .returns(optionalResponse)
+                .addStatement("return $T.empty()", OPTIONAL_CLASS)
+                .build());
+
+        builder.addMethod(MethodSpec.methodBuilder("defaultCreate")
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .addParameter(entityType, "entity")
+                .addParameter(serviceType, "service")
+                .returns(responseType)
+                .addStatement("return $T.status($T.CREATED).body(service.save(entity))",
+                        RESPONSE_ENTITY_CLASS, HTTP_STATUS_CLASS)
+                .build());
+    }
+
+    private static void addUpdateOverride(
+            TypeSpec.Builder builder,
+            ClassName entityType,
+            ClassName serviceType,
+            TypeName idType
+    ) {
+        TypeName responseType = ParameterizedTypeName.get(RESPONSE_ENTITY_CLASS, entityType);
+        TypeName optionalResponse = ParameterizedTypeName.get(OPTIONAL_CLASS, responseType);
+
+        builder.addMethod(MethodSpec.methodBuilder("update")
+                .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
+                .addParameter(idType, "id")
+                .addParameter(entityType, "entity")
+                .addParameter(serviceType, "service")
+                .returns(optionalResponse)
+                .addStatement("return $T.empty()", OPTIONAL_CLASS)
+                .build());
+
+        builder.addMethod(MethodSpec.methodBuilder("defaultUpdate")
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .addParameter(idType, "id")
+                .addParameter(entityType, "entity")
+                .addParameter(serviceType, "service")
+                .returns(responseType)
+                .addStatement("return service.update(id, entity)"
+                        + "\n        .map($T::ok)"
+                        + "\n        .orElse($T.notFound().build())",
+                        RESPONSE_ENTITY_CLASS, RESPONSE_ENTITY_CLASS)
+                .build());
+    }
+
+    private static void addDeleteOverride(
+            TypeSpec.Builder builder,
+            ClassName serviceType,
+            TypeName idType
+    ) {
+        TypeName responseType = ParameterizedTypeName.get(RESPONSE_ENTITY_CLASS, TypeName.VOID.box());
+        TypeName optionalResponse = ParameterizedTypeName.get(OPTIONAL_CLASS, responseType);
+
+        builder.addMethod(MethodSpec.methodBuilder("deleteById")
+                .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
+                .addParameter(idType, "id")
+                .addParameter(serviceType, "service")
+                .returns(optionalResponse)
+                .addStatement("return $T.empty()", OPTIONAL_CLASS)
+                .build());
+
+        builder.addMethod(MethodSpec.methodBuilder("defaultDeleteById")
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .addParameter(idType, "id")
+                .addParameter(serviceType, "service")
+                .returns(responseType)
+                .addStatement("return service.deleteById(id) ? $T.noContent().build() : $T.notFound().build()",
+                        RESPONSE_ENTITY_CLASS, RESPONSE_ENTITY_CLASS)
+                .build());
+    }
+}

--- a/sprout-processor/src/main/java/de/flix29/sprout/processor/SproutControllerProcessor.java
+++ b/sprout-processor/src/main/java/de/flix29/sprout/processor/SproutControllerProcessor.java
@@ -20,6 +20,9 @@ public class SproutControllerProcessor {
     private static final ClassName PATH_VARIABLE_CLASS = ClassName.get(SPRING_WEB_ANNOTATION_PACKAGE, "PathVariable");
     private static final ClassName RESPONSE_ENTITY_CLASS = ClassName.get("org.springframework.http", "ResponseEntity");
     private static final ClassName LIST_CLASS = ClassName.get("java.util", "List");
+    private static final ClassName OPTIONAL_CLASS = ClassName.get("java.util", "Optional");
+    private static final ClassName OBJECT_PROVIDER_CLASS =
+            ClassName.get("org.springframework.beans.factory", "ObjectProvider");
     private static final String APPLICATION_JSON = "application/json";
     private static final String ID = "/{id}";
     private static final String VALUE = "value";
@@ -39,6 +42,8 @@ public class SproutControllerProcessor {
     ) {
         final String componentName = "Sprout" + simpleName;
         ClassName service = ClassName.get(basePackage + ".services", componentName + "Service");
+        ClassName overrideType = ClassName.get(basePackage + ".controllers", componentName + "ControllerOverride");
+        TypeName overridesList = ParameterizedTypeName.get(LIST_CLASS, overrideType);
         var typeSpec = TypeSpec.classBuilder(componentName + "Controller")
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(ClassName.get(SPRING_WEB_ANNOTATION_PACKAGE, "RestController"))
@@ -53,26 +58,65 @@ public class SproutControllerProcessor {
                                 Modifier.PRIVATE, Modifier.FINAL
                         ).build()
                 )
+                .addField(FieldSpec.builder(
+                        overridesList, "overrides",
+                        Modifier.PRIVATE, Modifier.FINAL
+                ).build())
                 .addMethod(MethodSpec.constructorBuilder()
                         .addModifiers(Modifier.PUBLIC)
                         .addParameter(service, "service")
+                        .addParameter(ParameterizedTypeName.get(OBJECT_PROVIDER_CLASS, overrideType),
+                                "overridesProvider")
                         .addStatement("this.service = service")
+                        .addStatement("this.overrides = overridesProvider.orderedStream().toList()")
                         .build()
                 )
-                .addMethod(generateGetAllMethod(type, simpleName, policy == null ? null : policy.read()))
-                .addMethod(generateGetByIdMethod(type, simpleName, idType, policy == null ? null : policy.read()));
+                .addMethod(generateGetAllMethod(
+                        type,
+                        simpleName,
+                        policy == null ? null : policy.read(),
+                        overrideType
+                ))
+                .addMethod(generateGetByIdMethod(
+                        type,
+                        simpleName,
+                        idType,
+                        policy == null ? null : policy.read(),
+                        overrideType
+                ));
 
         if (!readOnly) {
             typeSpec
-                    .addMethod(generatePostMethod(type, simpleName, policy == null ? null : policy.create()))
-                    .addMethod(generatePutMethod(type, simpleName, idType, policy == null ? null : policy.update()))
-                    .addMethod(generateDeleteMethod(simpleName, idType, policy == null ? null : policy.delete()));
+                    .addMethod(generatePostMethod(
+                            type,
+                            simpleName,
+                            policy == null ? null : policy.create(),
+                            overrideType
+                    ))
+                    .addMethod(generatePutMethod(
+                            type,
+                            simpleName,
+                            idType,
+                            policy == null ? null : policy.update(),
+                            overrideType
+                    ))
+                    .addMethod(generateDeleteMethod(
+                            simpleName,
+                            idType,
+                            policy == null ? null : policy.delete(),
+                            overrideType
+                    ));
         }
 
         return typeSpec;
     }
 
-    private static MethodSpec generateGetAllMethod(TypeElement type, String simpleName, String policy) {
+    private static MethodSpec generateGetAllMethod(
+            TypeElement type,
+            String simpleName,
+            String policy,
+            ClassName overrideType
+    ) {
         var methodSpec = MethodSpec.methodBuilder("getAll")
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(AnnotationSpec
@@ -87,7 +131,21 @@ public class SproutControllerProcessor {
                         )
                 ))
                 .addJavadoc("Returns all $L items.\n", simpleName)
-                .addStatement("return $T.ok(service.findAll())", RESPONSE_ENTITY_CLASS);
+                .beginControlFlow("for (var override : overrides)")
+                .addStatement("$T response = override.getAll(service)",
+                        ParameterizedTypeName.get(
+                                OPTIONAL_CLASS,
+                                ParameterizedTypeName.get(
+                                        RESPONSE_ENTITY_CLASS,
+                                        ParameterizedTypeName.get(LIST_CLASS, ClassName.get(type))
+                                )
+                        )
+                )
+                .beginControlFlow("if (response.isPresent())")
+                .addStatement("return response.get()")
+                .endControlFlow()
+                .endControlFlow()
+                .addStatement("return $T.defaultGetAll(service)", overrideType);
 
         if (policy != null && !policy.isBlank()) {
             methodSpec.addAnnotation(generatePreAuthorizeAnnotation(policy));
@@ -97,7 +155,11 @@ public class SproutControllerProcessor {
     }
 
     private static MethodSpec generateGetByIdMethod(
-            TypeElement type, String simpleName, TypeMirror idType, String policy
+            TypeElement type,
+            String simpleName,
+            TypeMirror idType,
+            String policy,
+            ClassName overrideType
     ) {
         var methodSpec = MethodSpec.methodBuilder("getById")
                 .addModifiers(Modifier.PUBLIC)
@@ -115,13 +177,21 @@ public class SproutControllerProcessor {
                         ClassName.get(type)
                 ))
                 .addJavadoc("Returns a single $L item by its ID.\n", simpleName)
-                .addStatement("""
-                                return service.findById(id)
-                                        .map($T::ok)
-                                        .orElse($T.notFound().build())
-                                """,
-                        RESPONSE_ENTITY_CLASS, RESPONSE_ENTITY_CLASS
-                );
+                .beginControlFlow("for (var override : overrides)")
+                .addStatement("$T response = override.getById(id, service)",
+                        ParameterizedTypeName.get(
+                                OPTIONAL_CLASS,
+                                ParameterizedTypeName.get(
+                                        RESPONSE_ENTITY_CLASS,
+                                        ClassName.get(type)
+                                )
+                        )
+                )
+                .beginControlFlow("if (response.isPresent())")
+                .addStatement("return response.get()")
+                .endControlFlow()
+                .endControlFlow()
+                .addStatement("return $T.defaultGetById(id, service)", overrideType);
 
         if (policy != null && !policy.isBlank()) {
             methodSpec.addAnnotation(generatePreAuthorizeAnnotation(policy));
@@ -130,7 +200,12 @@ public class SproutControllerProcessor {
         return methodSpec.build();
     }
 
-    private static MethodSpec generatePostMethod(TypeElement type, String simpleName, String policy) {
+    private static MethodSpec generatePostMethod(
+            TypeElement type,
+            String simpleName,
+            String policy,
+            ClassName overrideType
+    ) {
         var methodSpec = MethodSpec.methodBuilder("create")
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(AnnotationSpec
@@ -148,9 +223,22 @@ public class SproutControllerProcessor {
                         ClassName.get(type)
                 ))
                 .addJavadoc("Creates a new $L item.\n", simpleName)
-                .addStatement("return $T.status($T.CREATED).body(service.save(new$L))",
-                        RESPONSE_ENTITY_CLASS, ClassName.get("org.springframework.http", "HttpStatus"), simpleName
-                );
+                .beginControlFlow("for (var override : overrides)")
+                .addStatement("$T response = override.create(new$L, service)",
+                        ParameterizedTypeName.get(
+                                OPTIONAL_CLASS,
+                                ParameterizedTypeName.get(
+                                        RESPONSE_ENTITY_CLASS,
+                                        ClassName.get(type)
+                                )
+                        ),
+                        simpleName
+                )
+                .beginControlFlow("if (response.isPresent())")
+                .addStatement("return response.get()")
+                .endControlFlow()
+                .endControlFlow()
+                .addStatement("return $T.defaultCreate(new$L, service)", overrideType, simpleName);
 
         if (policy != null && !policy.isBlank()) {
             methodSpec.addAnnotation(generatePreAuthorizeAnnotation(policy));
@@ -159,7 +247,13 @@ public class SproutControllerProcessor {
         return methodSpec.build();
     }
 
-    private static MethodSpec generatePutMethod(TypeElement type, String simpleName, TypeMirror idType, String policy) {
+    private static MethodSpec generatePutMethod(
+            TypeElement type,
+            String simpleName,
+            TypeMirror idType,
+            String policy,
+            ClassName overrideType
+    ) {
         var methodSpec = MethodSpec.methodBuilder("update")
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(AnnotationSpec
@@ -184,13 +278,22 @@ public class SproutControllerProcessor {
                         ClassName.get(type)
                 ))
                 .addJavadoc("Updates an existing $L item by its ID.\n", simpleName)
-                .addStatement("""
-                                return service.update(id, updated$L)
-                                    .map($T::ok)
-                                    .orElse($T.notFound().build())
-                                """,
-                        simpleName, RESPONSE_ENTITY_CLASS, RESPONSE_ENTITY_CLASS
-                );
+                .beginControlFlow("for (var override : overrides)")
+                .addStatement("$T response = override.update(id, updated$L, service)",
+                        ParameterizedTypeName.get(
+                                OPTIONAL_CLASS,
+                                ParameterizedTypeName.get(
+                                        RESPONSE_ENTITY_CLASS,
+                                        ClassName.get(type)
+                                )
+                        ),
+                        simpleName
+                )
+                .beginControlFlow("if (response.isPresent())")
+                .addStatement("return response.get()")
+                .endControlFlow()
+                .endControlFlow()
+                .addStatement("return $T.defaultUpdate(id, updated$L, service)", overrideType, simpleName);
 
         if (policy != null && !policy.isBlank()) {
             methodSpec.addAnnotation(generatePreAuthorizeAnnotation(policy));
@@ -199,7 +302,12 @@ public class SproutControllerProcessor {
         return methodSpec.build();
     }
 
-    private static MethodSpec generateDeleteMethod(String simpleName, TypeMirror idType, String policy) {
+    private static MethodSpec generateDeleteMethod(
+            String simpleName,
+            TypeMirror idType,
+            String policy,
+            ClassName overrideType
+    ) {
         var methodSpec = MethodSpec.methodBuilder("deleteById")
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(AnnotationSpec
@@ -218,9 +326,21 @@ public class SproutControllerProcessor {
                         TypeName.VOID.box()
                 ))
                 .addJavadoc("Deletes an existing $L item by its ID.\n", simpleName)
-                .addStatement("return service.deleteById(id) ? $T.noContent().build() : $T.notFound().build()",
-                        RESPONSE_ENTITY_CLASS, RESPONSE_ENTITY_CLASS
-                );
+                .beginControlFlow("for (var override : overrides)")
+                .addStatement("$T response = override.deleteById(id, service)",
+                        ParameterizedTypeName.get(
+                                OPTIONAL_CLASS,
+                                ParameterizedTypeName.get(
+                                        RESPONSE_ENTITY_CLASS,
+                                        TypeName.VOID.box()
+                                )
+                        )
+                )
+                .beginControlFlow("if (response.isPresent())")
+                .addStatement("return response.get()")
+                .endControlFlow()
+                .endControlFlow()
+                .addStatement("return $T.defaultDeleteById(id, service)", overrideType);
 
         if (policy != null && !policy.isBlank()) {
             methodSpec.addAnnotation(generatePreAuthorizeAnnotation(policy));

--- a/sprout-processor/src/main/java/de/flix29/sprout/processor/SproutProcessor.java
+++ b/sprout-processor/src/main/java/de/flix29/sprout/processor/SproutProcessor.java
@@ -136,11 +136,20 @@ public class SproutProcessor extends AbstractProcessor {
                     idType
             );
 
+            var controllerOverride = SproutControllerOverrideGenerator.generateControllerOverride(
+                    type,
+                    simpleName,
+                    basePackage,
+                    annotation.readOnly(),
+                    idType
+            );
+
             JavaFile markerFile = createJavaFile(basePackage + ".marker", marker);
             JavaFile repositoryFile = createJavaFile(basePackage + ".repositories", repository);
             JavaFile serviceFile = createJavaFile(basePackage + ".services", service);
+            JavaFile controllerOverrideFile = createJavaFile(basePackage + ".controllers", controllerOverride);
             JavaFile controllerFile = createJavaFile(basePackage + ".controllers", controller);
-            writeFiles(markerFile, repositoryFile, serviceFile, controllerFile);
+            writeFiles(markerFile, repositoryFile, serviceFile, controllerOverrideFile, controllerFile);
         }
         return true;
     }


### PR DESCRIPTION
## Summary
- generate a `Sprout<Entity>ControllerOverride` interface for every resource to expose optional endpoint hooks
- update controller generation to delegate to registered overrides before falling back to the default behaviour
- document how applications can register override beans to customize generated endpoints without editing generated sources

## Testing
- mvn -q -pl sprout-processor test *(fails: dependency resolution blocked by repository access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68fa99219ee0832a953f4c51d5496e59