### PR TITLE
Add override interface support for generated controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,37 @@ This is enabled by default when you include the sprout-runtime dependency. It'll
 
 ### Method-Level Security
 In addition to the `@SproutPolicy` annotation, you can use the `sprout.security.enabled` property to enable method-level security for your endpoints. This will use Spring Security to enforce access control based on the policies defined in your entities.
+
+## Customizing Generated Endpoints
+
+Every generated controller now looks for an optional override bean that can replace the default CRUD logic on a per-endpoint basis.
+For an entity named `Order`, Sprout generates an interface called `SproutOrderControllerOverride` in the `generated.controllers` package. Implement this interface, register it as a Spring bean (for example with `@Component`), and return a custom `ResponseEntity` from the endpoints you want to replace. Returning `Optional.empty()` keeps the default behaviour for that method.
+Replace `<your package>` with the package that contains your generated classes when importing the service.
+
+```java
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+// import <your package>.generated.controllers.SproutOrderControllerOverride;
+// import <your package>.generated.services.SproutOrderService;
+
+@Component
+public class OrderControllerOverride implements SproutOrderControllerOverride {
+
+    @Override
+    public Optional<ResponseEntity<List<Order>>> create(Order newOrder, SproutOrderService service) {
+        // add custom business logic before falling back to the generated service
+        if (newOrder.isExpress()) {
+            return Optional.of(ResponseEntity.status(HttpStatus.ACCEPTED)
+                    .body(service.save(newOrder)));
+        }
+        return Optional.empty();
+    }
+}
+```
+
+All override methods receive the generated service instance so you can reuse the default repository-backed implementation or compose it with domain-specific behaviour.

--- a/sprout-processor/src/main/java/de/flix29/sprout/processor/SproutControllerProcessor.java
+++ b/sprout-processor/src/main/java/de/flix29/sprout/processor/SproutControllerProcessor.java
@@ -20,6 +20,7 @@ public class SproutControllerProcessor {
     private static final ClassName PATH_VARIABLE_CLASS = ClassName.get(SPRING_WEB_ANNOTATION_PACKAGE, "PathVariable");
     private static final ClassName RESPONSE_ENTITY_CLASS = ClassName.get("org.springframework.http", "ResponseEntity");
     private static final ClassName LIST_CLASS = ClassName.get("java.util", "List");
+    private static final ClassName OPTIONAL_CLASS = ClassName.get("java.util", "Optional");
     private static final String APPLICATION_JSON = "application/json";
     private static final String ID = "/{id}";
     private static final String VALUE = "value";
@@ -39,6 +40,10 @@ public class SproutControllerProcessor {
     ) {
         final String componentName = "Sprout" + simpleName;
         ClassName service = ClassName.get(basePackage + ".services", componentName + "Service");
+        ClassName overrideClass = ClassName.get(
+                basePackage + ".controllers", componentName + "ControllerOverride"
+        );
+
         var typeSpec = TypeSpec.classBuilder(componentName + "Controller")
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(ClassName.get(SPRING_WEB_ANNOTATION_PACKAGE, "RestController"))
@@ -53,10 +58,17 @@ public class SproutControllerProcessor {
                                 Modifier.PRIVATE, Modifier.FINAL
                         ).build()
                 )
+                .addField(FieldSpec.builder(
+                                ParameterizedTypeName.get(OPTIONAL_CLASS, overrideClass), "override",
+                                Modifier.PRIVATE, Modifier.FINAL
+                        ).build()
+                )
                 .addMethod(MethodSpec.constructorBuilder()
                         .addModifiers(Modifier.PUBLIC)
                         .addParameter(service, "service")
+                        .addParameter(ParameterizedTypeName.get(OPTIONAL_CLASS, overrideClass), "override")
                         .addStatement("this.service = service")
+                        .addStatement("this.override = override == null ? $T.empty() : override", OPTIONAL_CLASS)
                         .build()
                 )
                 .addMethod(generateGetAllMethod(type, simpleName, policy == null ? null : policy.read()))
@@ -70,6 +82,80 @@ public class SproutControllerProcessor {
         }
 
         return typeSpec;
+    }
+
+    protected static TypeSpec.Builder generateControllerOverride(
+            TypeElement type,
+            String simpleName,
+            String basePackage,
+            TypeMirror idType
+    ) {
+        final String componentName = "Sprout" + simpleName;
+        ClassName service = ClassName.get(basePackage + ".services", componentName + "Service");
+        ClassName entityType = ClassName.get(type);
+
+        var builder = TypeSpec.interfaceBuilder(componentName + "ControllerOverride")
+                .addModifiers(Modifier.PUBLIC)
+                .addMethod(MethodSpec.methodBuilder("getAll")
+                        .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
+                        .addParameter(service, "service")
+                        .returns(ParameterizedTypeName.get(
+                                OPTIONAL_CLASS,
+                                ParameterizedTypeName.get(
+                                        RESPONSE_ENTITY_CLASS,
+                                        ParameterizedTypeName.get(LIST_CLASS, entityType)
+                                )
+                        ))
+                        .addStatement("return $T.empty()", OPTIONAL_CLASS)
+                        .build()
+                )
+                .addMethod(MethodSpec.methodBuilder("getById")
+                        .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
+                        .addParameter(TypeName.get(idType), "id")
+                        .addParameter(service, "service")
+                        .returns(ParameterizedTypeName.get(
+                                OPTIONAL_CLASS,
+                                ParameterizedTypeName.get(RESPONSE_ENTITY_CLASS, entityType.box())
+                        ))
+                        .addStatement("return $T.empty()", OPTIONAL_CLASS)
+                        .build()
+                )
+                .addMethod(MethodSpec.methodBuilder("create")
+                        .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
+                        .addParameter(entityType, "new" + simpleName)
+                        .addParameter(service, "service")
+                        .returns(ParameterizedTypeName.get(
+                                OPTIONAL_CLASS,
+                                ParameterizedTypeName.get(RESPONSE_ENTITY_CLASS, entityType.box())
+                        ))
+                        .addStatement("return $T.empty()", OPTIONAL_CLASS)
+                        .build()
+                )
+                .addMethod(MethodSpec.methodBuilder("update")
+                        .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
+                        .addParameter(TypeName.get(idType), "id")
+                        .addParameter(entityType, "updated" + simpleName)
+                        .addParameter(service, "service")
+                        .returns(ParameterizedTypeName.get(
+                                OPTIONAL_CLASS,
+                                ParameterizedTypeName.get(RESPONSE_ENTITY_CLASS, entityType.box())
+                        ))
+                        .addStatement("return $T.empty()", OPTIONAL_CLASS)
+                        .build()
+                )
+                .addMethod(MethodSpec.methodBuilder("deleteById")
+                        .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
+                        .addParameter(TypeName.get(idType), "id")
+                        .addParameter(service, "service")
+                        .returns(ParameterizedTypeName.get(
+                                OPTIONAL_CLASS,
+                                ParameterizedTypeName.get(RESPONSE_ENTITY_CLASS, TypeName.VOID.box())
+                        ))
+                        .addStatement("return $T.empty()", OPTIONAL_CLASS)
+                        .build()
+                );
+
+        return builder;
     }
 
     private static MethodSpec generateGetAllMethod(TypeElement type, String simpleName, String policy) {
@@ -87,7 +173,12 @@ public class SproutControllerProcessor {
                         )
                 ))
                 .addJavadoc("Returns all $L items.\n", simpleName)
-                .addStatement("return $T.ok(service.findAll())", RESPONSE_ENTITY_CLASS);
+                .addStatement("""
+                                return override.flatMap(custom -> custom.getAll(service))
+                                        .orElseGet(() -> $T.ok(service.findAll()))
+                                """,
+                        RESPONSE_ENTITY_CLASS
+                );
 
         if (policy != null && !policy.isBlank()) {
             methodSpec.addAnnotation(generatePreAuthorizeAnnotation(policy));
@@ -116,9 +207,10 @@ public class SproutControllerProcessor {
                 ))
                 .addJavadoc("Returns a single $L item by its ID.\n", simpleName)
                 .addStatement("""
-                                return service.findById(id)
-                                        .map($T::ok)
-                                        .orElse($T.notFound().build())
+                                return override.flatMap(custom -> custom.getById(id, service))
+                                        .orElseGet(() -> service.findById(id)
+                                                .map($T::ok)
+                                                .orElse($T.notFound().build()))
                                 """,
                         RESPONSE_ENTITY_CLASS, RESPONSE_ENTITY_CLASS
                 );
@@ -148,7 +240,11 @@ public class SproutControllerProcessor {
                         ClassName.get(type)
                 ))
                 .addJavadoc("Creates a new $L item.\n", simpleName)
-                .addStatement("return $T.status($T.CREATED).body(service.save(new$L))",
+                .addStatement("""
+                                return override.flatMap(custom -> custom.create(new$L, service))
+                                        .orElseGet(() -> $T.status($T.CREATED).body(service.save(new$L)))
+                                """,
+                        simpleName,
                         RESPONSE_ENTITY_CLASS, ClassName.get("org.springframework.http", "HttpStatus"), simpleName
                 );
 
@@ -185,11 +281,12 @@ public class SproutControllerProcessor {
                 ))
                 .addJavadoc("Updates an existing $L item by its ID.\n", simpleName)
                 .addStatement("""
-                                return service.update(id, updated$L)
-                                    .map($T::ok)
-                                    .orElse($T.notFound().build())
+                                return override.flatMap(custom -> custom.update(id, updated$L, service))
+                                        .orElseGet(() -> service.update(id, updated$L)
+                                                .map($T::ok)
+                                                .orElse($T.notFound().build()))
                                 """,
-                        simpleName, RESPONSE_ENTITY_CLASS, RESPONSE_ENTITY_CLASS
+                        simpleName, simpleName, RESPONSE_ENTITY_CLASS, RESPONSE_ENTITY_CLASS
                 );
 
         if (policy != null && !policy.isBlank()) {
@@ -218,7 +315,12 @@ public class SproutControllerProcessor {
                         TypeName.VOID.box()
                 ))
                 .addJavadoc("Deletes an existing $L item by its ID.\n", simpleName)
-                .addStatement("return service.deleteById(id) ? $T.noContent().build() : $T.notFound().build()",
+                .addStatement("""
+                                return override.flatMap(custom -> custom.deleteById(id, service))
+                                        .orElseGet(() -> service.deleteById(id)
+                                                ? $T.noContent().build()
+                                                : $T.notFound().build())
+                                """,
                         RESPONSE_ENTITY_CLASS, RESPONSE_ENTITY_CLASS
                 );
 

--- a/sprout-processor/src/main/java/de/flix29/sprout/processor/SproutProcessor.java
+++ b/sprout-processor/src/main/java/de/flix29/sprout/processor/SproutProcessor.java
@@ -135,12 +135,19 @@ public class SproutProcessor extends AbstractProcessor {
                     apiPath,
                     idType
             );
+            var controllerOverride = SproutControllerProcessor.generateControllerOverride(
+                    type,
+                    simpleName,
+                    basePackage,
+                    idType
+            );
 
             JavaFile markerFile = createJavaFile(basePackage + ".marker", marker);
             JavaFile repositoryFile = createJavaFile(basePackage + ".repositories", repository);
             JavaFile serviceFile = createJavaFile(basePackage + ".services", service);
+            JavaFile controllerOverrideFile = createJavaFile(basePackage + ".controllers", controllerOverride);
             JavaFile controllerFile = createJavaFile(basePackage + ".controllers", controller);
-            writeFiles(markerFile, repositoryFile, serviceFile, controllerFile);
+            writeFiles(markerFile, repositoryFile, serviceFile, controllerOverrideFile, controllerFile);
         }
         return true;
     }


### PR DESCRIPTION
## Summary
- allow generated controllers to consume optional override beans and delegate endpoint logic when present
- generate controller override interfaces for each resource
- document how to plug in custom overrides for generated endpoints

## Testing
- mvn -pl sprout-processor test *(fails: repository access blocked by 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68fa99219ee0832a953f4c51d5496e59