### PR TITLE
feat: allow overriding generated controller logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,25 @@ This is enabled by default when you include the sprout-runtime dependency. It'll
 
 ### Method-Level Security
 In addition to the `@SproutPolicy` annotation, you can use the `sprout.security.enabled` property to enable method-level security for your endpoints. This will use Spring Security to enforce access control based on the policies defined in your entities.
+
+### Customizing Generated Endpoints
+Sometimes you want to change the behaviour of a generated endpoint without touching the generated source code. Sprout provides an
+extension point for this scenario. For each entity you can declare a bean that implements the
+`SproutControllerDelegate<T, ID>` interface (available in the `sprout-runtime` module). The generated controller will pick up the
+delegate automatically and forward all incoming requests to it. Every method on the delegate receives callbacks to the default
+implementation so that you can compose your custom logic with the generated behaviour as needed.
+
+```java
+@Component
+class BookControllerDelegate implements SproutControllerDelegate<Book, UUID> {
+
+    @Override
+    public ResponseEntity<List<Book>> getAll(Supplier<List<Book>> findAll) {
+        var books = findAll.get();
+        // apply custom business logic here
+        return ResponseEntity.ok(books);
+    }
+}
+```
+
+If no delegate bean is present, Sprout falls back to the default CRUD behaviour.

--- a/sprout-processor/src/main/java/de/flix29/sprout/processor/SproutControllerProcessor.java
+++ b/sprout-processor/src/main/java/de/flix29/sprout/processor/SproutControllerProcessor.java
@@ -19,6 +19,10 @@ public class SproutControllerProcessor {
     private static final String SPRING_WEB_ANNOTATION_PACKAGE = "org.springframework.web.bind.annotation";
     private static final ClassName PATH_VARIABLE_CLASS = ClassName.get(SPRING_WEB_ANNOTATION_PACKAGE, "PathVariable");
     private static final ClassName RESPONSE_ENTITY_CLASS = ClassName.get("org.springframework.http", "ResponseEntity");
+    private static final ClassName OBJECT_PROVIDER_CLASS =
+            ClassName.get("org.springframework.beans.factory", "ObjectProvider");
+    private static final ClassName CONTROLLER_DELEGATE_CLASS =
+            ClassName.get("de.flix29.sprout.runtime.controller", "SproutControllerDelegate");
     private static final ClassName LIST_CLASS = ClassName.get("java.util", "List");
     private static final String APPLICATION_JSON = "application/json";
     private static final String ID = "/{id}";
@@ -39,6 +43,11 @@ public class SproutControllerProcessor {
     ) {
         final String componentName = "Sprout" + simpleName;
         ClassName service = ClassName.get(basePackage + ".services", componentName + "Service");
+        var delegateType = ParameterizedTypeName.get(
+                CONTROLLER_DELEGATE_CLASS,
+                ClassName.get(type),
+                TypeName.get(idType)
+        );
         var typeSpec = TypeSpec.classBuilder(componentName + "Controller")
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(ClassName.get(SPRING_WEB_ANNOTATION_PACKAGE, "RestController"))
@@ -53,10 +62,21 @@ public class SproutControllerProcessor {
                                 Modifier.PRIVATE, Modifier.FINAL
                         ).build()
                 )
+                .addField(FieldSpec.builder(
+                                delegateType, "delegate",
+                                Modifier.PRIVATE, Modifier.FINAL
+                        ).build()
+                )
                 .addMethod(MethodSpec.constructorBuilder()
                         .addModifiers(Modifier.PUBLIC)
                         .addParameter(service, "service")
+                        .addParameter(ParameterizedTypeName.get(OBJECT_PROVIDER_CLASS, delegateType), "delegateProvider")
                         .addStatement("this.service = service")
+                        .addStatement("$T delegate = delegateProvider.getIfAvailable()", delegateType)
+                        .beginControlFlow("if (delegate == null)")
+                        .addStatement("delegate = new $T<>() {}", delegateType)
+                        .endControlFlow()
+                        .addStatement("this.delegate = delegate")
                         .build()
                 )
                 .addMethod(generateGetAllMethod(type, simpleName, policy == null ? null : policy.read()))
@@ -87,7 +107,7 @@ public class SproutControllerProcessor {
                         )
                 ))
                 .addJavadoc("Returns all $L items.\n", simpleName)
-                .addStatement("return $T.ok(service.findAll())", RESPONSE_ENTITY_CLASS);
+                .addStatement("return delegate.getAll(service::findAll)");
 
         if (policy != null && !policy.isBlank()) {
             methodSpec.addAnnotation(generatePreAuthorizeAnnotation(policy));
@@ -115,13 +135,7 @@ public class SproutControllerProcessor {
                         ClassName.get(type)
                 ))
                 .addJavadoc("Returns a single $L item by its ID.\n", simpleName)
-                .addStatement("""
-                                return service.findById(id)
-                                        .map($T::ok)
-                                        .orElse($T.notFound().build())
-                                """,
-                        RESPONSE_ENTITY_CLASS, RESPONSE_ENTITY_CLASS
-                );
+                .addStatement("return delegate.getById(id, service::findById)");
 
         if (policy != null && !policy.isBlank()) {
             methodSpec.addAnnotation(generatePreAuthorizeAnnotation(policy));
@@ -148,9 +162,7 @@ public class SproutControllerProcessor {
                         ClassName.get(type)
                 ))
                 .addJavadoc("Creates a new $L item.\n", simpleName)
-                .addStatement("return $T.status($T.CREATED).body(service.save(new$L))",
-                        RESPONSE_ENTITY_CLASS, ClassName.get("org.springframework.http", "HttpStatus"), simpleName
-                );
+                .addStatement("return delegate.create(new$L, service::save)", simpleName);
 
         if (policy != null && !policy.isBlank()) {
             methodSpec.addAnnotation(generatePreAuthorizeAnnotation(policy));
@@ -184,13 +196,7 @@ public class SproutControllerProcessor {
                         ClassName.get(type)
                 ))
                 .addJavadoc("Updates an existing $L item by its ID.\n", simpleName)
-                .addStatement("""
-                                return service.update(id, updated$L)
-                                    .map($T::ok)
-                                    .orElse($T.notFound().build())
-                                """,
-                        simpleName, RESPONSE_ENTITY_CLASS, RESPONSE_ENTITY_CLASS
-                );
+                .addStatement("return delegate.update(id, updated$L, service::update)", simpleName);
 
         if (policy != null && !policy.isBlank()) {
             methodSpec.addAnnotation(generatePreAuthorizeAnnotation(policy));
@@ -218,9 +224,7 @@ public class SproutControllerProcessor {
                         TypeName.VOID.box()
                 ))
                 .addJavadoc("Deletes an existing $L item by its ID.\n", simpleName)
-                .addStatement("return service.deleteById(id) ? $T.noContent().build() : $T.notFound().build()",
-                        RESPONSE_ENTITY_CLASS, RESPONSE_ENTITY_CLASS
-                );
+                .addStatement("return delegate.delete(id, service::deleteById)");
 
         if (policy != null && !policy.isBlank()) {
             methodSpec.addAnnotation(generatePreAuthorizeAnnotation(policy));

--- a/sprout-runtime/src/main/java/de/flix29/sprout/runtime/controller/SproutControllerDelegate.java
+++ b/sprout-runtime/src/main/java/de/flix29/sprout/runtime/controller/SproutControllerDelegate.java
@@ -1,0 +1,84 @@
+package de.flix29.sprout.runtime.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Allows applications to customize the behaviour of the generated Sprout controllers without modifying the
+ * generated source files. By providing a bean that implements this interface for a specific entity, the
+ * application can override individual endpoint handlers while still having access to the default implementation
+ * through the provided callbacks.
+ *
+ * @param <T>  the entity type handled by the controller
+ * @param <ID> the identifier type of the entity
+ */
+public interface SproutControllerDelegate<T, ID> {
+
+    /**
+     * Handles {@code GET /api/{entity}} requests.
+     *
+     * @param findAll callback that executes the default lookup logic
+     * @return the response to return from the controller
+     */
+    default ResponseEntity<List<T>> getAll(Supplier<List<T>> findAll) {
+        return ResponseEntity.ok(findAll.get());
+    }
+
+    /**
+     * Handles {@code GET /api/{entity}/{id}} requests.
+     *
+     * @param id       the entity identifier supplied by the client
+     * @param findById callback that executes the default lookup logic
+     * @return the response to return from the controller
+     */
+    default ResponseEntity<T> getById(ID id, Function<ID, Optional<T>> findById) {
+        return findById.apply(id)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Handles {@code POST /api/{entity}} requests.
+     *
+     * @param entity the new entity provided by the client
+     * @param save   callback that executes the default persistence logic
+     * @return the response to return from the controller
+     */
+    default ResponseEntity<T> create(T entity, Function<T, T> save) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(save.apply(entity));
+    }
+
+    /**
+     * Handles {@code PUT /api/{entity}/{id}} requests.
+     *
+     * @param id      the entity identifier supplied by the client
+     * @param entity  the updated entity provided by the client
+     * @param update  callback that executes the default update logic
+     * @return the response to return from the controller
+     */
+    default ResponseEntity<T> update(ID id, T entity, BiFunction<ID, T, Optional<T>> update) {
+        return update.apply(id, entity)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Handles {@code DELETE /api/{entity}/{id}} requests.
+     *
+     * @param id     the entity identifier supplied by the client
+     * @param delete callback that executes the default deletion logic
+     * @return the response to return from the controller
+     */
+    default ResponseEntity<Void> delete(ID id, Function<ID, Boolean> delete) {
+        return Boolean.TRUE.equals(delete.apply(id))
+                ? ResponseEntity.noContent().build()
+                : ResponseEntity.notFound().build();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a `SproutControllerDelegate` runtime extension point that exposes callbacks for the default CRUD behaviour
- make generated controllers resolve an optional delegate via `ObjectProvider` and route endpoint logic through it
- document the customization workflow for applications that want to override generated endpoints

## Testing
- `mvn -pl sprout-processor -am test` *(fails: Maven Central returns 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa99219ee0832a953f4c51d5496e59