### PR TITLE
Allow overriding generated beans with conditional registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,33 @@ Sprout also offers several optional features that you can enable by adding addit
 - `@SproutPolicy` Lets you define custom access policies for your each endpoint.
 - `@SproutId` Lets you define which field of your entity should be used as the ID field if you don't want to use the Database ID.
 
+### Overriding Generated Logic
+
+Every generated service now exposes a `Sprout{Name}Operations` interface that is used by the controller.
+The generated `Sprout{Name}Service` is registered with `@ConditionalOnMissingBean`, so if you provide your own Spring bean that implements the operations interface, Sprout automatically backs off and uses your implementation instead.
+
+You can either implement the interface directly or extend the generated service and override only the methods you need:
+
+```java
+@Service
+class CustomBookOperations extends SproutBookService {
+
+    CustomBookOperations(SproutBookRepository repository) {
+        super(repository);
+    }
+
+    @Override
+    public List<Book> findAll() {
+        // add your business logic here
+        return super.findAll();
+    }
+}
+```
+
+Because the controller depends on the `Sprout{Name}Operations` contract instead of the generated service class, Spring injects your bean transparently without any additional configuration.
+
+If you ever need to replace the controller altogether—for example to change request mappings—you can provide your own `Sprout{Name}Controller` bean (e.g. by subclassing the generated controller). The generated controller is also guarded by `@ConditionalOnMissingBean`, so your custom bean will take precedence and the generated controller will be skipped automatically.
+
 If you add the sprout-runtime dependency to your project, you can also use the following features:
 
 ```xml

--- a/sprout-processor/src/main/java/de/flix29/sprout/processor/SproutControllerProcessor.java
+++ b/sprout-processor/src/main/java/de/flix29/sprout/processor/SproutControllerProcessor.java
@@ -19,6 +19,10 @@ public class SproutControllerProcessor {
     private static final String SPRING_WEB_ANNOTATION_PACKAGE = "org.springframework.web.bind.annotation";
     private static final ClassName PATH_VARIABLE_CLASS = ClassName.get(SPRING_WEB_ANNOTATION_PACKAGE, "PathVariable");
     private static final ClassName RESPONSE_ENTITY_CLASS = ClassName.get("org.springframework.http", "ResponseEntity");
+    private static final ClassName CONDITIONAL_ON_MISSING_BEAN = ClassName.get(
+            "org.springframework.boot.autoconfigure.condition",
+            "ConditionalOnMissingBean"
+    );
     private static final ClassName LIST_CLASS = ClassName.get("java.util", "List");
     private static final String APPLICATION_JSON = "application/json";
     private static final String ID = "/{id}";
@@ -38,7 +42,8 @@ public class SproutControllerProcessor {
             TypeMirror idType
     ) {
         final String componentName = "Sprout" + simpleName;
-        ClassName service = ClassName.get(basePackage + ".services", componentName + "Service");
+        ClassName operations = ClassName.get(basePackage + ".services", componentName + "Operations");
+        ClassName controllerType = ClassName.get(basePackage + ".controllers", componentName + "Controller");
         var typeSpec = TypeSpec.classBuilder(componentName + "Controller")
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(ClassName.get(SPRING_WEB_ANNOTATION_PACKAGE, "RestController"))
@@ -48,15 +53,19 @@ public class SproutControllerProcessor {
                         .addMember("produces", "$S", APPLICATION_JSON)
                         .build()
                 )
+                .addAnnotation(AnnotationSpec.builder(CONDITIONAL_ON_MISSING_BEAN)
+                        .addMember("value", "$T.class", controllerType)
+                        .build()
+                )
                 .addField(FieldSpec.builder(
-                                service, "service",
+                                operations, "operations",
                                 Modifier.PRIVATE, Modifier.FINAL
                         ).build()
                 )
                 .addMethod(MethodSpec.constructorBuilder()
                         .addModifiers(Modifier.PUBLIC)
-                        .addParameter(service, "service")
-                        .addStatement("this.service = service")
+                        .addParameter(operations, "operations")
+                        .addStatement("this.operations = operations")
                         .build()
                 )
                 .addMethod(generateGetAllMethod(type, simpleName, policy == null ? null : policy.read()))
@@ -87,7 +96,7 @@ public class SproutControllerProcessor {
                         )
                 ))
                 .addJavadoc("Returns all $L items.\n", simpleName)
-                .addStatement("return $T.ok(service.findAll())", RESPONSE_ENTITY_CLASS);
+                .addStatement("return $T.ok(operations.findAll())", RESPONSE_ENTITY_CLASS);
 
         if (policy != null && !policy.isBlank()) {
             methodSpec.addAnnotation(generatePreAuthorizeAnnotation(policy));
@@ -116,7 +125,7 @@ public class SproutControllerProcessor {
                 ))
                 .addJavadoc("Returns a single $L item by its ID.\n", simpleName)
                 .addStatement("""
-                                return service.findById(id)
+                                return operations.findById(id)
                                         .map($T::ok)
                                         .orElse($T.notFound().build())
                                 """,
@@ -148,7 +157,7 @@ public class SproutControllerProcessor {
                         ClassName.get(type)
                 ))
                 .addJavadoc("Creates a new $L item.\n", simpleName)
-                .addStatement("return $T.status($T.CREATED).body(service.save(new$L))",
+                .addStatement("return $T.status($T.CREATED).body(operations.save(new$L))",
                         RESPONSE_ENTITY_CLASS, ClassName.get("org.springframework.http", "HttpStatus"), simpleName
                 );
 
@@ -185,7 +194,7 @@ public class SproutControllerProcessor {
                 ))
                 .addJavadoc("Updates an existing $L item by its ID.\n", simpleName)
                 .addStatement("""
-                                return service.update(id, updated$L)
+                                return operations.update(id, updated$L)
                                     .map($T::ok)
                                     .orElse($T.notFound().build())
                                 """,
@@ -218,7 +227,7 @@ public class SproutControllerProcessor {
                         TypeName.VOID.box()
                 ))
                 .addJavadoc("Deletes an existing $L item by its ID.\n", simpleName)
-                .addStatement("return service.deleteById(id) ? $T.noContent().build() : $T.notFound().build()",
+                .addStatement("return operations.deleteById(id) ? $T.noContent().build() : $T.notFound().build()",
                         RESPONSE_ENTITY_CLASS, RESPONSE_ENTITY_CLASS
                 );
 

--- a/sprout-processor/src/main/java/de/flix29/sprout/processor/SproutOperationsGenerator.java
+++ b/sprout-processor/src/main/java/de/flix29/sprout/processor/SproutOperationsGenerator.java
@@ -1,0 +1,87 @@
+package de.flix29.sprout.processor;
+
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+
+final class SproutOperationsGenerator {
+
+    private static final ClassName LIST = ClassName.get("java.util", "List");
+    private static final ClassName OPTIONAL = ClassName.get("java.util", "Optional");
+
+    private SproutOperationsGenerator() {
+        // Utility class
+    }
+
+    protected static TypeSpec.Builder generateOperations(
+            TypeElement type,
+            String simpleName,
+            boolean readOnly,
+            TypeMirror idType
+    ) {
+        ClassName entityType = ClassName.get(type);
+        TypeName idT = TypeName.get(idType);
+
+        TypeSpec.Builder builder = TypeSpec.interfaceBuilder("Sprout" + simpleName + "Operations")
+                .addModifiers(Modifier.PUBLIC);
+
+        builder
+                .addMethod(createFindAllMethod(entityType))
+                .addMethod(createFindByIdMethod(entityType, idT));
+
+        if (!readOnly) {
+            builder
+                    .addMethod(createSaveMethod(entityType))
+                    .addMethod(createUpdateMethod(entityType, idT))
+                    .addMethod(createDeleteMethod(idT));
+        }
+
+        return builder;
+    }
+
+    private static MethodSpec createFindAllMethod(ClassName entityType) {
+        return MethodSpec.methodBuilder("findAll")
+                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                .returns(ParameterizedTypeName.get(LIST, entityType))
+                .build();
+    }
+
+    private static MethodSpec createFindByIdMethod(ClassName entityType, TypeName idT) {
+        return MethodSpec.methodBuilder("findById")
+                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                .addParameter(idT, "id")
+                .returns(ParameterizedTypeName.get(OPTIONAL, entityType))
+                .build();
+    }
+
+    private static MethodSpec createSaveMethod(ClassName entityType) {
+        return MethodSpec.methodBuilder("save")
+                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                .addParameter(entityType, "entity")
+                .returns(entityType)
+                .build();
+    }
+
+    private static MethodSpec createUpdateMethod(ClassName entityType, TypeName idT) {
+        return MethodSpec.methodBuilder("update")
+                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                .addParameter(idT, "id")
+                .addParameter(entityType, "entity")
+                .returns(ParameterizedTypeName.get(OPTIONAL, entityType))
+                .build();
+    }
+
+    private static MethodSpec createDeleteMethod(TypeName idT) {
+        return MethodSpec.methodBuilder("deleteById")
+                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                .addParameter(idT, "id")
+                .returns(TypeName.BOOLEAN)
+                .build();
+    }
+}

--- a/sprout-processor/src/main/java/de/flix29/sprout/processor/SproutProcessor.java
+++ b/sprout-processor/src/main/java/de/flix29/sprout/processor/SproutProcessor.java
@@ -115,6 +115,15 @@ public class SproutProcessor extends AbstractProcessor {
 
             processingEnv.getMessager().printMessage(
                     Diagnostic.Kind.NOTE,
+                    String.format("[Sprout] Generating%s operations for %s ",
+                            annotation.readOnly() ? " readonly" : "", simpleName
+                    )
+            );
+            var operations = SproutOperationsGenerator
+                    .generateOperations(type, simpleName, annotation.readOnly(), idType);
+
+            processingEnv.getMessager().printMessage(
+                    Diagnostic.Kind.NOTE,
                     String.format("[Sprout] Generating%s service for %s ",
                             annotation.readOnly() ? " readonly" : "", simpleName
                     )
@@ -138,9 +147,10 @@ public class SproutProcessor extends AbstractProcessor {
 
             JavaFile markerFile = createJavaFile(basePackage + ".marker", marker);
             JavaFile repositoryFile = createJavaFile(basePackage + ".repositories", repository);
+            JavaFile operationsFile = createJavaFile(basePackage + ".services", operations);
             JavaFile serviceFile = createJavaFile(basePackage + ".services", service);
             JavaFile controllerFile = createJavaFile(basePackage + ".controllers", controller);
-            writeFiles(markerFile, repositoryFile, serviceFile, controllerFile);
+            writeFiles(markerFile, repositoryFile, operationsFile, serviceFile, controllerFile);
         }
         return true;
     }

--- a/sprout-processor/src/main/java/de/flix29/sprout/processor/SproutServiceGenerator.java
+++ b/sprout-processor/src/main/java/de/flix29/sprout/processor/SproutServiceGenerator.java
@@ -16,10 +16,15 @@ public class SproutServiceGenerator {
 
     private static final ClassName LIST = ClassName.get("java.util", "List");
     private static final ClassName OPTIONAL = ClassName.get("java.util", "Optional");
+    private static final ClassName OVERRIDE = ClassName.get(Override.class);
     private static final ClassName BEAN_UTILS = ClassName.get("org.springframework.beans", "BeanUtils");
     private static final ClassName SERVICE = ClassName.get("org.springframework.stereotype", "Service");
     private static final ClassName TRANSACTIONAL =
             ClassName.get("org.springframework.transaction.annotation", "Transactional");
+    private static final ClassName CONDITIONAL_ON_MISSING_BEAN = ClassName.get(
+            "org.springframework.boot.autoconfigure.condition",
+            "ConditionalOnMissingBean"
+    );
 
     private SproutServiceGenerator() {
         // Utility class
@@ -30,12 +35,18 @@ public class SproutServiceGenerator {
     ) {
         final String componentName = "Sprout" + simpleName;
         final ClassName repository = ClassName.get(basePath + ".repositories", componentName + "Repository");
+        final ClassName operations = ClassName.get(basePath + ".services", componentName + "Operations");
         final ClassName entityType = ClassName.get(type);
         final TypeName idT = TypeName.get(idType);
 
         var builder = TypeSpec.classBuilder(componentName + "Service")
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(SERVICE)
+                .addAnnotation(AnnotationSpec.builder(CONDITIONAL_ON_MISSING_BEAN)
+                        .addMember("value", "$T.class", operations)
+                        .build()
+                )
+                .addSuperinterface(operations)
                 .addField(FieldSpec.builder(
                         repository, "repository", Modifier.PRIVATE, Modifier.FINAL
                 ).build())
@@ -65,6 +76,7 @@ public class SproutServiceGenerator {
 
     private static MethodSpec generateFindAllMethod(ClassName entityType) {
         return MethodSpec.methodBuilder("findAll")
+                .addAnnotation(OVERRIDE)
                 .addModifiers(Modifier.PUBLIC)
                 .returns(ParameterizedTypeName.get(LIST, entityType))
                 .addStatement("return repository.findAll()")
@@ -73,6 +85,7 @@ public class SproutServiceGenerator {
 
     private static MethodSpec generateFindByIdMethod(ClassName entityType, TypeName idT) {
         return MethodSpec.methodBuilder("findById")
+                .addAnnotation(OVERRIDE)
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(idT, "id")
                 .returns(ParameterizedTypeName.get(OPTIONAL, entityType))
@@ -83,6 +96,7 @@ public class SproutServiceGenerator {
     private static MethodSpec generateSaveMethod(ClassName entityType) {
         return MethodSpec.methodBuilder("save")
                 .addAnnotation(TRANSACTIONAL)
+                .addAnnotation(OVERRIDE)
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(entityType, "entity")
                 .returns(entityType)
@@ -93,6 +107,7 @@ public class SproutServiceGenerator {
     private static MethodSpec generateUpdateMethod(ClassName entityType, TypeName idT) {
         return MethodSpec.methodBuilder("update")
                 .addAnnotation(TRANSACTIONAL)
+                .addAnnotation(OVERRIDE)
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(idT, "id")
                 .addParameter(entityType, "entity")
@@ -107,6 +122,7 @@ public class SproutServiceGenerator {
     private static MethodSpec generateDeleteMethod(TypeName idT) {
         return MethodSpec.methodBuilder("deleteById")
                 .addAnnotation(TRANSACTIONAL)
+                .addAnnotation(OVERRIDE)
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(idT, "id")
                 .returns(TypeName.BOOLEAN)


### PR DESCRIPTION
## Summary
- guard generated controllers and services with `@ConditionalOnMissingBean` so custom beans can replace them cleanly
- document how to provide bespoke operations or controller implementations now that the generated beans back off automatically

## Testing
- mvn -pl sprout-processor -am -DskipTests package *(fails: Forbidden 403 while downloading dependencies in the sandboxed environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa99219ee0832a953f4c51d5496e59